### PR TITLE
Add GRPC Reflection service

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,13 +77,15 @@ func main() {
 	}()
 
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
-	reflectionservice.Register(grpcServer)
 	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, xdsServer)
 	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, xdsServer)
 	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, xdsServer)
 	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, xdsServer)
 	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, xdsServer)
 	loadreportingservice.RegisterLoadReportingServiceServer(grpcServer, report.NewServer(report.WithStatsIntervalInSeconds(statsIntervalInSeconds)))
+	if os.Getenv("ENABLE_GRPC_REFLECTION") == "true" {
+		reflectionservice.Register(grpcServer)
+	}
 
 	lis, err := net.Listen("tcp", ":5000") //nolint:gosec
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	reflectionservice "google.golang.org/grpc/reflection"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
@@ -76,6 +77,7 @@ func main() {
 	}()
 
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+	reflectionservice.Register(grpcServer)
 	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, xdsServer)
 	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, xdsServer)
 	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, xdsServer)


### PR DESCRIPTION
Small PR that adds [GRPC reflection](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md) support. 

Makes it easier to use tools like Postman or grpcurl to see what APIs server exposes and to call them.

I know that the state can be seen using port 9000, but it's easier to explain what XDS server does to others by showing exact XDS APIs that are exposed, otherwise it's a little bit of a blackbox and requires proto files to call it.