### PR TITLE
Adjust log level for endpoints to be less verbose, and more precise stack trace

### DIFF
--- a/snapshot/endpoints.go
+++ b/snapshot/endpoints.go
@@ -53,7 +53,7 @@ func (s *Snapshotter) startEndpoints(ctx context.Context) error {
 		hash, err := resourcesHash(endpointsResources)
 		if err == nil {
 			if hash == lastSnapshotHash {
-				klog.V(4).Info("new snapshot is equivalent to the previous one")
+				klog.V(5).Info("new snapshot is equivalent to the previous one")
 				return
 			}
 			lastSnapshotHash = hash

--- a/snapshot/snapshotter.go
+++ b/snapshot/snapshotter.go
@@ -18,16 +18,16 @@ import (
 
 var Logger log.Logger = &log.LoggerFuncs{
 	DebugFunc: func(s string, i ...interface{}) {
-		klog.V(4).Infof(s, i...)
+		klog.V(4).InfofDepth(1, s, i...)
 	},
 	InfoFunc: func(s string, i ...interface{}) {
-		klog.V(2).Infof(s, i...)
+		klog.V(2).InfofDepth(1, s, i...)
 	},
 	WarnFunc: func(s string, i ...interface{}) {
-		klog.Warningf(s, i...)
+		klog.WarningfDepth(1, s, i...)
 	},
 	ErrorFunc: func(s string, i ...interface{}) {
-		klog.Errorf(s, i...)
+		klog.ErrorfDepth(1, s, i...)
 	},
 }
 


### PR DESCRIPTION
The "no change" log is very verbose when using -v=4 and doesn't do anything much. Bumping it to v=5 so that we can safely enable -v=4 when req/res logging is needed.

This also fix the logging adapter so that the reported file is correct according to the original logging source.