### PR TITLE
Add partial test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 
 require (
 	cel.dev/expr v0.24.0 // indirect
+	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
@@ -40,6 +41,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.8.0 // indirect
 	github.com/go-chi/chi/v5 v5.0.7 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
@@ -63,11 +65,15 @@ require (
 	github.com/prometheus/common v0.64.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/zeebo/errs v1.4.0 // indirect
 	github.com/zhangyunhao116/sbconv v0.2.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+cloud.google.com/go/compute/metadata v0.6.0 h1:A6hENjEsCDtC1k8byVsgwvVcioamEHvZ4j01OwKxG9I=
+cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1FlqW3Rga40jzHL4hfg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/ccoveille/go-safecast v1.2.0 h1:H4X7aosepsU1Mfk+098CTdKpsDH0cfYJ2RmwXFjgvfc=
@@ -28,6 +30,8 @@ github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vt
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -107,6 +111,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8WS0hE=
+github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
@@ -118,6 +124,8 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
+github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zhangyunhao116/sbconv v0.2.1 h1:9Z43QFpnkYNjCrRz8UR9ShVRVQ0OG5VtLKQ3mAL5zjU=
 github.com/zhangyunhao116/sbconv v0.2.1/go.mod h1:pdAXGnJGNM68XNdJOfGCelkEHgrQMWSeW/2/qKjuiQQ=
 github.com/zhangyunhao116/wyhash v0.4.0 h1:w/mkH+okJy4MvmQFojNbyW+5WAy+dF9TDB/0RW2xuYk=
@@ -148,6 +156,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
+golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
+golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/internal/di/grpc.go
+++ b/internal/di/grpc.go
@@ -20,9 +20,14 @@ var GrpcSet = wire.NewSet(
 	ProvideSideEffectGrpcChannelzRegistered,
 )
 
-func ProvideGrpcServer() (*grpc.Server, func()) {
-	// TODO: Refactor otel
-	server := grpc.NewServer(grpc.StatsHandler(otelgrpc.NewServerHandler()))
+func ProvideOtelGrpcServerOptions() []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+	}
+}
+
+func ProvideGrpcServer(serverOptions []grpc.ServerOption) (*grpc.Server, func()) {
+	server := grpc.NewServer(serverOptions...)
 	return server, func() {
 		server.GracefulStop()
 	}

--- a/internal/di/k8sxds.go
+++ b/internal/di/k8sxds.go
@@ -22,7 +22,7 @@ var K8sXdsSet = wire.NewSet(
 	ProvideLRSServer,
 )
 
-func ProvideSnapshotter(ctx context.Context, k8sClient *kubernetes.Clientset) (*snapshot.Snapshotter, func()) {
+func ProvideSnapshotter(ctx context.Context, k8sClient kubernetes.Interface) (*snapshot.Snapshotter, func()) {
 	stopCtx, stop := context.WithCancel(ctx)
 	snapshotter := snapshot.New(k8sClient)
 

--- a/internal/di/kubernetes.go
+++ b/internal/di/kubernetes.go
@@ -45,7 +45,7 @@ func ProvideK8sHTTPClient(transport K8sHTTPTransport, config *rest.Config) K8sHT
 	}
 }
 
-func ProvideK8sClient(clientConfig *rest.Config, httpClient K8sHTTPClient) (*kubernetes.Clientset, error) {
+func ProvideK8sClient(clientConfig *rest.Config, httpClient K8sHTTPClient) (kubernetes.Interface, error) {
 	clientset, err := kubernetes.NewForConfigAndClient(clientConfig, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)

--- a/internal/di/test.go
+++ b/internal/di/test.go
@@ -1,0 +1,21 @@
+package di
+
+import (
+	"github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	"github.com/google/wire"
+	"google.golang.org/grpc"
+)
+
+type TestServer struct {
+	DevServer
+
+	Server server.Server
+}
+
+var TestSet = wire.NewSet(
+	ProvideGrpcTestOption,
+)
+
+func ProvideGrpcTestOption() []grpc.ServerOption {
+	return []grpc.ServerOption{}
+}

--- a/internal/di/wire.go
+++ b/internal/di/wire.go
@@ -7,16 +7,22 @@ import (
 	"github.com/google/wire"
 	"github.com/wongnai/xds/debug"
 	"google.golang.org/grpc"
+	"k8s.io/client-go/kubernetes"
 )
 
 type Servers struct {
+	DevServer
+
 	_GrpcHealth SideEffectGrpcHealthRegistered
-	_Xds        XdsAllSideEffects
 	_Reflection SideEffectGrpcReflectionRegistered
 	_Channelz   SideEffectGrpcChannelzRegistered
 
-	GrpcServer  *grpc.Server
 	DebugServer *debug.Server
+}
+
+type DevServer struct {
+	_Xds       XdsAllSideEffects
+	GrpcServer *grpc.Server
 }
 
 func InitializeServer(ctx context.Context, statsIntervalSeconds StatsIntervalSeconds) (Servers, func(), error) {
@@ -25,7 +31,22 @@ func InitializeServer(ctx context.Context, statsIntervalSeconds StatsIntervalSec
 		GrpcSet,
 		K8sXdsSet,
 		XdsSet,
+		ProvideOtelGrpcServerOptions,
+		wire.Struct(new(DevServer), "*"),
 		wire.Struct(new(Servers), "*"),
 	)
 	return Servers{}, nil, nil
+}
+
+func InitializeTestServer(ctx context.Context, kubeClient kubernetes.Interface, statsIntervalSeconds StatsIntervalSeconds) (TestServer, func(), error) {
+	wire.Build(
+		GrpcSet,
+		K8sXdsSet,
+		XdsSet,
+		TestSet,
+		wire.Struct(new(DevServer), "*"),
+		wire.Struct(new(TestServer), "*"),
+	)
+
+	return TestServer{}, nil, nil
 }

--- a/snapshot/services.go
+++ b/snapshot/services.go
@@ -37,10 +37,10 @@ func (s *Snapshotter) startServices(ctx context.Context) error {
 	}, k8scache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	reflector := k8scache.NewReflector(&k8scache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 			return s.client.CoreV1().Services("").List(ctx, options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 			return s.client.CoreV1().Services("").Watch(ctx, options)
 		},
 	}, &corev1.Service{}, store, s.ResyncPeriod)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1,0 +1,258 @@
+package test_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/wongnai/xds/internal/di"
+	"github.com/wongnai/xds/snapshot/apigateway"
+	"github.com/wongnai/xds/test"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/xds"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
+)
+
+// xdsServerBind is where the xDS Server is listening. Since the port is :0, use s.listener.Addr().String() to get the actual address
+const xdsServerBind = "127.2.0.1:0"
+
+type XdsIntegrationTestSuite struct {
+	suite.Suite
+	di.TestServer
+
+	listener           net.Listener
+	kube               *fake.Clientset
+	activeFakeServices []*test.FakeService
+
+	fakeServiceIP uint8
+}
+
+func (s *XdsIntegrationTestSuite) SetupSuite() {
+	listener, err := net.Listen("tcp", xdsServerBind)
+	s.Require().NoError(err)
+	s.listener = listener
+
+	go func() {
+		err := s.TestServer.GrpcServer.Serve(listener)
+		if err != nil {
+			s.T().Error(err)
+		}
+	}()
+}
+
+func (s *XdsIntegrationTestSuite) TearDownTest() {
+	// TODO: Clear s.kube.Tracker
+	s.kube.ClearActions()
+	for _, service := range s.activeFakeServices {
+		service.AssertExpectations(s.T())
+		service.Stop()
+	}
+	s.activeFakeServices = nil
+	s.fakeServiceIP = 0
+	klog.Flush()
+}
+
+func (s *XdsIntegrationTestSuite) TearDownSuite() {
+	s.TestServer.GrpcServer.Stop()
+	s.listener.Close()
+}
+
+func (s *XdsIntegrationTestSuite) getClient(target string) grpc_health_v1.HealthClient {
+	xdsBuilder, err := xds.NewXDSResolverWithConfigForTesting([]byte(fmt.Sprintf(`{
+		"xds_servers": [{
+			"server_uri": "%s",
+			"channel_creds": [{"type": "insecure"}],
+            "server_features": ["xds_v3"]
+		}],
+		"node": {
+			"id": "test",
+			"locality": {
+				"zone" : "test"
+			}
+		}
+	}`, s.listener.Addr().String())))
+	s.Require().NoError(err)
+	client, err := grpc.NewClient(target, grpc.WithResolvers(xdsBuilder), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	s.Require().NoError(err)
+
+	healthClient := grpc_health_v1.NewHealthClient(client)
+	return healthClient
+}
+
+func (s *XdsIntegrationTestSuite) createFakeService(serviceName string, namespace string, port int32, register bool) *test.FakeService {
+	svc, err := test.NewFakeService(fmt.Sprintf("%s:%d", s.getFakeServiceIP(), port))
+	s.Require().NoError(err)
+	svc.Test(s.T())
+	s.activeFakeServices = append(s.activeFakeServices, svc)
+
+	if register {
+		s.createKubeService(serviceName, namespace, port)
+		s.createKubeEndpoint(serviceName, namespace, svc.Host(), svc.Port())
+	}
+
+	return svc
+}
+
+func (s *XdsIntegrationTestSuite) createKubeService(serviceName string, namespace string, servicePort int32) {
+	svc := &test.K8SService{
+		Name:      serviceName,
+		Namespace: namespace,
+		Ports: []corev1.ServicePort{{
+			Name:     "grpc",
+			Port:     servicePort,
+			Protocol: corev1.ProtocolTCP,
+		}},
+	}
+	err := s.kube.Tracker().Add(svc.AsK8S())
+	s.Require().NoError(err)
+}
+
+func (s *XdsIntegrationTestSuite) createKubeEndpoint(serviceName string, namespace string, ip string, port int32) {
+	endpoint := &test.K8SEndpoint{
+		Name:      serviceName,
+		Namespace: namespace,
+		IP:        []string{ip},
+		Ports: []corev1.EndpointPort{{
+			Name: "grpc",
+			Port: port,
+		}},
+	}
+	err := s.kube.Tracker().Add(endpoint.AsK8S()) //nolint:staticcheck // We use Endpoint to simulate legacy Kube compatibility
+	s.Require().NoError(err)
+}
+
+func (s *XdsIntegrationTestSuite) getFakeServiceIP() string {
+	out := s.fakeServiceIP
+	s.fakeServiceIP += 1
+
+	return fmt.Sprintf("127.2.1.%d", out)
+}
+
+func (s *XdsIntegrationTestSuite) TestValidTarget() {
+	svc := s.createFakeService("app", "default", 0, false)
+	s.createKubeService("app", "default", 1)
+	s.createKubeEndpoint("app", "default", svc.Host(), svc.Port())
+
+	// Test that the client is able to connect
+	client := s.getClient("xds:///app.default:1")
+	s.T().Run("initial", func(t *testing.T) {
+		svc.On("Check", mock.Anything, "test").Return(&grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil)
+
+		_, err := client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: "test"})
+		assert.NoError(t, err)
+	})
+
+	// Test that once the backend IP change, the client connects to the new one
+	svc.Stop() // Stop the old one
+
+	// Create unrelated apps to simulate unrelated events
+	s.createKubeService("app", "unused", 1)
+	s.createKubeEndpoint("app", "unused", "0.0.0.1", 1)
+
+	svc = s.createFakeService("app", "default", 0, false)
+	err := s.kube.Tracker().Update(
+		schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"},
+		&corev1.Endpoints{ //nolint:staticcheck // We use Endpoint to simulate legacy Kube compatibility
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Endpoints",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "app",
+				Namespace: "default",
+			},
+			Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck // See above
+				Addresses: []corev1.EndpointAddress{{ //nolint:staticcheck // See above
+					IP: svc.Host(),
+				}},
+				Ports: []corev1.EndpointPort{ //nolint:staticcheck // See above
+					{
+						Name: "grpc",
+						Port: svc.Port(),
+					},
+					{
+						Name: "http",
+						Port: 9999,
+					},
+				},
+			}},
+		},
+		"default",
+	)
+	s.Require().NoError(err)
+
+	// It doesn't seems that XDS propagation works in test??
+	// s.T().Run("updated", func(t *testing.T) {
+	//	svc.On("Check", mock.Anything, "test2").Return(&grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil)
+	//
+	//	_, err := client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{Service: "test2"})
+	//	assert.NoError(t, err)
+	// })
+}
+
+func (s *XdsIntegrationTestSuite) TestApiGateway() {
+	svc1 := s.createFakeService("apigwbackend1", "default", 50000, false)
+	svc1Manifest := &test.K8SService{
+		Name:      "apigwbackend1",
+		Namespace: "default",
+		Annotations: map[string]string{
+			apigateway.NameAnnotation:    "apigw1,apigw2",
+			apigateway.ServiceAnnotation: "grpc.health.v1.Health,lmwn.inexists.v1.Test",
+		},
+		Ports: []corev1.ServicePort{{
+			Name:     "grpc",
+			Port:     50000,
+			Protocol: corev1.ProtocolTCP,
+		}},
+	}
+	err := s.kube.Tracker().Add(svc1Manifest.AsK8S())
+	s.Require().NoError(err)
+	s.createKubeEndpoint("apigwbackend1", "default", svc1.Host(), svc1.Port())
+
+	svc2 := s.createFakeService("apigwbackend2", "default", 50001, false)
+	svc2Manifest := &test.K8SService{
+		Name:      "apigwbackend2",
+		Namespace: "default",
+		Annotations: map[string]string{
+			apigateway.NameAnnotation:    "apigw1,apigw2",
+			apigateway.ServiceAnnotation: "",
+		},
+		Ports: []corev1.ServicePort{{
+			Name:     "grpc",
+			Port:     50001,
+			Protocol: corev1.ProtocolTCP,
+		}},
+	}
+	err = s.kube.Tracker().Add(svc2Manifest.AsK8S())
+	s.Require().NoError(err)
+	s.createKubeEndpoint("apigwbackend2", "default", svc2.Host(), svc2.Port())
+
+	svc1.On("Check", mock.Anything, "test").Return(&grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil)
+
+	client := s.getClient("xds:///apigw1")
+	_, err = client.Check(s.T().Context(), &grpc_health_v1.HealthCheckRequest{Service: "test"})
+	require.NoError(s.T(), err)
+}
+
+func TestXdsIntegration(t *testing.T) {
+	kube := fake.NewClientset()
+
+	testServer, stop, err := di.InitializeTestServer(t.Context(), kube, 1)
+	require.NoError(t, err)
+	defer stop()
+
+	suite.Run(t, &XdsIntegrationTestSuite{
+		TestServer: testServer,
+		kube:       kube,
+	})
+}

--- a/test/kubemanifest.go
+++ b/test/kubemanifest.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type K8SService struct {
+	Name        string
+	Namespace   string
+	Ports       []corev1.ServicePort
+	Annotations map[string]string
+}
+
+func (k *K8SService) AsK8S() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        k.Name,
+			Namespace:   k.Namespace,
+			Annotations: k.Annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: k.Ports,
+		},
+	}
+}
+
+type K8SEndpoint struct {
+	Name      string
+	Namespace string
+	IP        []string
+	Ports     []corev1.EndpointPort //nolint:staticcheck // We use Endpoint to simulate legacy Kube compatibility
+}
+
+func (k *K8SEndpoint) AsK8S() *corev1.Endpoints { //nolint:staticcheck // We use Endpoint to simulate legacy Kube compatibility
+	addresses := make([]corev1.EndpointAddress, len(k.IP)) //nolint:staticcheck // See above
+	for i, ip := range k.IP {
+		addresses[i] = corev1.EndpointAddress{IP: ip} //nolint:staticcheck // See above
+	}
+	return &corev1.Endpoints{ //nolint:staticcheck // See above
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Endpoints"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k.Name,
+			Namespace: k.Namespace,
+		},
+		Subsets: []corev1.EndpointSubset{{ //nolint:staticcheck // See above
+			Addresses: addresses,
+			Ports:     k.Ports,
+		}},
+	}
+}

--- a/test/package.go
+++ b/test/package.go
@@ -1,0 +1,1 @@
+package test

--- a/test/service.go
+++ b/test/service.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"context"
+	"net"
+	"strconv"
+
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type FakeService struct {
+	mock.Mock
+
+	listener   net.Listener
+	grpcServer *grpc.Server
+}
+
+func NewFakeService(addr string) (*FakeService, error) {
+	server := grpc.NewServer()
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	service := FakeService{
+		listener:   listener,
+		grpcServer: server,
+	}
+
+	grpc_health_v1.RegisterHealthServer(server, &service)
+
+	go server.Serve(listener)
+
+	return &service, nil
+}
+
+func (f *FakeService) Check(ctx context.Context, request *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	args := f.Called(ctx, request.Service)
+	return args.Get(0).(*grpc_health_v1.HealthCheckResponse), args.Error(1)
+}
+
+func (f *FakeService) List(ctx context.Context, request *grpc_health_v1.HealthListRequest) (*grpc_health_v1.HealthListResponse, error) {
+	panic("not implemented")
+}
+
+func (f *FakeService) Watch(request *grpc_health_v1.HealthCheckRequest, g grpc.ServerStreamingServer[grpc_health_v1.HealthCheckResponse]) error {
+	panic("not implemented")
+}
+
+func (f *FakeService) Stop() {
+	f.grpcServer.Stop()
+	f.listener.Close()
+}
+
+func (f *FakeService) Addr() net.Addr {
+	return f.listener.Addr()
+}
+
+func (f *FakeService) Host() string {
+	host, _, err := net.SplitHostPort(f.Addr().String())
+	if err != nil {
+		panic(err)
+	}
+	return host
+}
+
+func (f *FakeService) Port() int32 {
+	_, portStr, err := net.SplitHostPort(f.Addr().String())
+	if err != nil {
+		panic(err)
+	}
+	port, err := strconv.ParseInt(portStr, 10, 32)
+	if err != nil {
+		panic(err)
+	}
+	return int32(port)
+}

--- a/test/xds_test.go
+++ b/test/xds_test.go
@@ -1,0 +1,103 @@
+package test_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/stretchr/testify/suite"
+	"github.com/wongnai/xds/internal/di"
+	"github.com/wongnai/xds/test"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type XdsSuite struct {
+	suite.Suite
+	di.TestServer
+
+	kube *fake.Clientset
+	stop func()
+	conn *bufconn.Listener
+}
+
+func (s *XdsSuite) SetupTest() {
+	var err error
+	s.kube = fake.NewClientset()
+	s.conn = bufconn.Listen(1)
+	s.TestServer, s.stop, err = di.InitializeTestServer(s.T().Context(), s.kube, 1)
+	s.Require().NoError(err)
+
+	go s.TestServer.GrpcServer.Serve(s.conn)
+}
+
+func (s *XdsSuite) TearDownTest() {
+	if s.stop != nil {
+		s.stop()
+	}
+	s.TestServer.GrpcServer.Stop()
+	s.conn.Close()
+}
+
+func (s *XdsSuite) GetGrpcClient() *grpc.ClientConn {
+	out, err := grpc.NewClient("passthrough:internal", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return s.conn.DialContext(ctx)
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	s.Require().NoError(err)
+
+	return out
+}
+
+func (s *XdsSuite) TestEndpointInfo() {
+	const svcName = "test-service"
+	const svcNamespace = "default"
+	fakeSvc := &test.K8SService{
+		Name:      svcName,
+		Namespace: svcNamespace,
+		Ports: []corev1.ServicePort{{
+			Name: "grpc",
+			Port: 50000,
+		}},
+	}
+	s.kube.Tracker().Add(fakeSvc.AsK8S())
+
+	fakeEndpoint := &test.K8SEndpoint{
+		Name:      svcName,
+		Namespace: svcNamespace,
+		IP:        []string{"127.0.0.1"},
+		Ports: []corev1.EndpointPort{{
+			Name: "grpc",
+			Port: 50000,
+		}},
+	}
+	s.kube.Tracker().Add(fakeEndpoint.AsK8S())
+
+	ads := discoveryv3.NewAggregatedDiscoveryServiceClient(s.GetGrpcClient())
+	adsStream, err := ads.StreamAggregatedResources(s.T().Context())
+	s.Require().NoError(err)
+	defer adsStream.CloseSend()
+
+	adsStream.Send(&discoveryv3.DiscoveryRequest{
+		VersionInfo: "",
+		Node:        test.FakeNode(),
+		ResourceNames: []string{
+			"test-service.default:grpc",
+		},
+		TypeUrl: resource.APITypePrefix + resource.EndpointType,
+	})
+
+	s.T().Skip("This test doesn't work currently and is left for smoke testing")
+
+	// discovery, err := adsStream.Recv()
+	// s.Require().NoError(err)
+	// s.T().Logf("%s", discovery.String())
+}
+
+func TestXds(t *testing.T) {
+	suite.Run(t, &XdsSuite{})
+}

--- a/test/xdsmanifest.go
+++ b/test/xdsmanifest.go
@@ -1,0 +1,10 @@
+package test
+
+import corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+
+func FakeNode() *corev3.Node {
+	return &corev3.Node{
+		Id:      "fake",
+		Cluster: "fake",
+	}
+}


### PR DESCRIPTION
# Test that works
- Integration test
   - Test that Go xDS client does work
   - Test that virtual API gateway does work
- xDS API test
   - Nothing...

# Test that doesn't work
These are left in the source but disabled

- Integration test
  - Test that Go xDS receive updated endpoint information
  - Some other test ideas that has not been written at all
     - Virtual API gateway (VAG) receive updated endpoint information
     - VAG support 1 service in multiple VAG
     - VAG support 1 service providing multiple gRPC packages
     - VAG support multiple services providing the same gRPC package (for strangler architecture)
- xDS API test
   - Test that endpoint information is received